### PR TITLE
fix: remove semicolon char from studio-component.tsx

### DIFF
--- a/packages/sanity-astro/src/studio/studio-component.tsx
+++ b/packages/sanity-astro/src/studio/studio-component.tsx
@@ -21,7 +21,7 @@ export function StudioComponent() {
         overflow: 'hidden',
       }}
     >
-      <Studio config={config} />;
+      <Studio config={config} />
     </div>
   )
 }


### PR DESCRIPTION
Remove a semicolon that was probably added by mistake